### PR TITLE
Allow using self-signed SSL certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Improve end-to-end integration testing with maven. Process Executor Plugin allow
 * __workingDir__: Give a working directory for your process to start in. Could be same as name. If not provided, the build directory is used.
 * __waitForInterrupt__: Optional. Setting this value to true will pause your build after starting every process to give you a chance to manually play with your system. Default is false.
 * __healthcheckUrl__: Recommended, but optional. You should provide a healthcheck url, so the plugin waits until the healthchecks are all green for your process. If not provided, the plugin waits for `waitAfterLaunch` seconds before moving on.
+* __healthcheckValidateSsl__: Optional.  If healthcheckUrl is specified, and is an HTTPS URL, Java's default SSL TrustManager will be used by default.  If you are using a self-signed certificate, this parameter can be set to false to use a TrustManager that doesn't validate the certification path.
 * __waitAfterLaunch__: Optional. This specifies the maximum time in seconds to wait after launching the process. If healthcheckUrl is specified, then it will move on as soon as the health checks pass. Default is 30 seconds.
 * __processLogFile__: Optional. Specifying a log file will redirect the process output to the specified file. Recommended as this will avoid cluttering your build's log with the log of external proccesses.
 

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,11 @@
             <artifactId>commons-exec</artifactId>
             <version>1.2</version>
         </dependency>
+        <dependency>
+            <groupId>commons-net</groupId>
+            <artifactId>commons-net</artifactId>
+            <version>3.5</version>
+        </dependency>
 
         <!-- Testing -->
         <dependency>

--- a/src/main/java/com/bazaarvoice/maven/plugin/process/AbstractProcessMojo.java
+++ b/src/main/java/com/bazaarvoice/maven/plugin/process/AbstractProcessMojo.java
@@ -25,6 +25,9 @@ public abstract class AbstractProcessMojo extends AbstractMojo {
     @Parameter(property = "exec.healthcheckUrl")
     protected String healthcheckUrl;
 
+    @Parameter(property = "exec.healthcheckValidateSsl", defaultValue = "true")
+    protected boolean healthcheckValidateSsl;
+
     @Parameter(property = "exec.waitAfterLaunch", required = false, defaultValue = "30")
     protected int waitAfterLaunch;
 

--- a/src/main/java/com/bazaarvoice/maven/plugin/process/ProcessHealthCondition.java
+++ b/src/main/java/com/bazaarvoice/maven/plugin/process/ProcessHealthCondition.java
@@ -1,5 +1,9 @@
 package com.bazaarvoice.maven.plugin.process;
 
+import org.apache.commons.net.util.SSLContextUtils;
+import org.apache.commons.net.util.TrustManagerUtils;
+
+import javax.net.ssl.*;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
@@ -7,13 +11,17 @@ import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.ProtocolException;
 import java.net.URL;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
 
 public class ProcessHealthCondition {
     private static final int SECONDS_BETWEEN_CHECKS = 1;
 
     private ProcessHealthCondition() {}
 
-    public static void waitSecondsUntilHealthy(String healthCheckUrl, int timeoutInSeconds) {
+    public static void waitSecondsUntilHealthy(String healthCheckUrl, int timeoutInSeconds, boolean validateSsl) {
         if (healthCheckUrl == null) {
             // Wait for timeout seconds to let the process come up
             sleep(timeoutInSeconds);
@@ -21,28 +29,47 @@ public class ProcessHealthCondition {
         }
         final long start = System.currentTimeMillis();
         final URL url = url(healthCheckUrl);
+
+        SSLSocketFactory sslSocketFactory;
+
+        try {
+            if (validateSsl) {
+                sslSocketFactory = SSLContext.getDefault().getSocketFactory();
+            } else {
+                sslSocketFactory = SSLContextUtils.createSSLContext("TLS", null,
+                        TrustManagerUtils.getAcceptAllTrustManager()).getSocketFactory();
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to obtain SSLSocketFactory", e);
+        }
+
         while ((System.currentTimeMillis() - start) / 1000 < timeoutInSeconds) {
             internalSleep();
-            if (is200(url)) {
+            if (is200(url, sslSocketFactory)) {
                 return; // success!!!
             }
         }
         throw new RuntimeException("Process was not healthy even after " + timeoutInSeconds + " seconds");
     }
 
-    private static boolean is200(URL url) {
+    private static boolean is200(URL url, SSLSocketFactory sslSocketFactory) {
         try {
-            final int code = getResponseCode(url);
+            final int code = getResponseCode(url, sslSocketFactory);
             return 200 <= code && code < 300;
         } catch (Exception e) {
             return false;
         }
     }
 
-    private static int getResponseCode(URL url) {
+    private static int getResponseCode(URL url, SSLSocketFactory sslSocketFactory) {
         InputStream in = null;
         try {
             final HttpURLConnection http = (HttpURLConnection) url.openConnection();
+
+            if (http instanceof HttpsURLConnection) {
+                ((HttpsURLConnection) http).setSSLSocketFactory(sslSocketFactory);
+            }
+
             http.setRequestMethod("GET");
             http.connect();
             in = http.getInputStream();
@@ -87,4 +114,5 @@ public class ProcessHealthCondition {
             }
         } catch (Exception e) {/**/}
     }
+
 }

--- a/src/main/java/com/bazaarvoice/maven/plugin/process/ProcessStartMojo.java
+++ b/src/main/java/com/bazaarvoice/maven/plugin/process/ProcessStartMojo.java
@@ -40,7 +40,7 @@ public class ProcessStartMojo extends AbstractProcessMojo {
         getLog().info("Starting process: " + exec.getName());
         exec.execute(processWorkingDirectory(), getLog(), arguments);
         CrossMojoState.addProcess(exec, getPluginContext());
-        ProcessHealthCondition.waitSecondsUntilHealthy(healthcheckUrl, waitAfterLaunch);
+        ProcessHealthCondition.waitSecondsUntilHealthy(healthcheckUrl, waitAfterLaunch, healthcheckValidateSsl);
         getLog().info("Started process: " + exec.getName());
     }
 


### PR DESCRIPTION
Refs: https://github.com/bazaarvoice/maven-process-plugin/pull/15

- Added healthcheckValidateSsl parameter, along with support for using an SSLSocketFactory for HTTPS health checks that doesn't validate the certificate trust path.