### PR TITLE
Allow any self signed certs regardless of the host for https connections for the health check

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,14 @@ Improve end-to-end integration testing with maven. Process Executor Plugin allow
 *NOTE:* As of 0.7, killing the maven process (using Ctrl+C or kill <pid> command) will stop all the processes started by the plugin.
 
 ## POM example:
-This version is `0.9-Genesys-SNAPSHOT`.
+This version is `0.10-Genesys-SNAPSHOT`.
 
     <build>
         <plugins>
             <plugin>
                 <groupId>com.bazaarvoice.maven.plugins</groupId>
                 <artifactId>process-exec-maven-plugin</artifactId>
-                <version>0.9-Genesys-SNAPSHOT</version>
+                <version>0.10-Genesys-SNAPSHOT</version>
                 <executions>
                     <!--Start process 1, eg., a dropwizard app dependency-->
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <groupId>com.bazaarvoice.maven.plugins</groupId>
     <artifactId>process-exec-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
-    <version>0.9-Genesys-SNAPSHOT</version>
+    <version>0.10-Genesys-SNAPSHOT</version>
 
     <name>Process execution maven plugin</name>
 

--- a/src/main/java/com/bazaarvoice/maven/plugin/process/ProcessHealthCondition.java
+++ b/src/main/java/com/bazaarvoice/maven/plugin/process/ProcessHealthCondition.java
@@ -68,6 +68,12 @@ public class ProcessHealthCondition {
 
             if (http instanceof HttpsURLConnection) {
                 ((HttpsURLConnection) http).setSSLSocketFactory(sslSocketFactory);
+                HttpsURLConnection.setDefaultHostnameVerifier(new HostnameVerifier() {
+                    @Override
+                    public boolean verify(String arg0, SSLSession arg1) {
+                        return true;
+                    }
+                });
             }
 
             http.setRequestMethod("GET");

--- a/src/main/java/com/bazaarvoice/maven/plugin/process/ProcessHealthCondition.java
+++ b/src/main/java/com/bazaarvoice/maven/plugin/process/ProcessHealthCondition.java
@@ -67,8 +67,9 @@ public class ProcessHealthCondition {
             final HttpURLConnection http = (HttpURLConnection) url.openConnection();
 
             if (http instanceof HttpsURLConnection) {
-                ((HttpsURLConnection) http).setSSLSocketFactory(sslSocketFactory);
-                HttpsURLConnection.setDefaultHostnameVerifier(new HostnameVerifier() {
+                HttpsURLConnection httpConnHandler = (HttpsURLConnection) http;
+                httpConnHandler.setSSLSocketFactory(sslSocketFactory);
+                httpConnHandler.setHostnameVerifier(new HostnameVerifier() {
                     @Override
                     public boolean verify(String arg0, SSLSession arg1) {
                         return true;


### PR DESCRIPTION
It is not exactly pertinent that the SSL certificates have valid host names for the health check, so allowing the https connections to verify SSL certificates regardless of the host name makes sense to me.